### PR TITLE
✨ feat: add helper function to fix imgur links and update image link …

### DIFF
--- a/base.go
+++ b/base.go
@@ -79,12 +79,14 @@ func (b *baseCrawler) worker(destDir string, linkChan chan string, wg *sync.Wait
 	defer wg.Done()
 
 	for target := range linkChan {
-		// Create request with custom Referer if needed.
 		req, err := http.NewRequest("GET", target, nil)
 		if err != nil {
 			log.Printf("http.NewRequest error: %s, target: %s", err, target)
 			continue
 		}
+		// Set User-Agent header
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+		// Set Referer header if target is from i.imgur.com
 		if strings.Contains(target, "i.imgur.com") {
 			re := regexp.MustCompile(`([^\/]+)\.(jpg|jpeg|png)`)
 			matches := re.FindStringSubmatch(target)
@@ -92,6 +94,7 @@ func (b *baseCrawler) worker(destDir string, linkChan chan string, wg *sync.Wait
 				req.Header.Set("Referer", "https://imgur.com/"+matches[1])
 			}
 		}
+
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {

--- a/ptt.go
+++ b/ptt.go
@@ -43,14 +43,23 @@ func extractTitle(doc *goquery.Document) string {
 	return title
 }
 
+// Add helper function to fix imgur links.
+func fixImgurLink(link string) string {
+	if strings.Contains(link, "https://imgur.com/") {
+		parts := strings.Split(link, "/")
+		imageID := parts[len(parts)-1]
+		return "https://i.imgur.com/" + imageID + ".jpeg"
+	}
+	return link
+}
+
 func extractImageLinks(doc *goquery.Document) []string {
 	var links []string
 	doc.Find("a").Each(func(i int, s *goquery.Selection) {
 		imgLink, _ := s.Attr("href")
 		if isImageLink(imgLink) {
-			if strings.Contains(imgLink, "https://imgur.com/") {
-				imgLink = imgLink + ".jpg"
-			}
+			// Replace imgur.com link using helper.
+			imgLink = fixImgurLink(imgLink)
 			links = append(links, imgLink)
 		}
 	})
@@ -79,9 +88,8 @@ func (p *PTT) GetAllFromURL(url string) (title string, allImages []string, like,
 	doc.Find("a").Each(func(i int, s *goquery.Selection) {
 		imgLink, _ := s.Attr("href")
 		if isImageLink(imgLink) {
-			if strings.Contains(imgLink, "https://imgur.com/") {
-				imgLink = imgLink + ".jpg"
-			}
+			// Replace imgur.com link using helper.
+			imgLink = fixImgurLink(imgLink)
 			allImages = append(allImages, imgLink)
 			foundImage = true
 		}
@@ -177,9 +185,8 @@ func (p *PTT) GetAllImageAddress(target string) []string {
 	doc.Find("a").Each(func(i int, s *goquery.Selection) {
 		imgLink, _ := s.Attr("href")
 		if isImageLink(imgLink) {
-			if strings.Contains(imgLink, "https://imgur.com/") {
-				imgLink = imgLink + ".jpg"
-			}
+			// Replace imgur.com link using helper.
+			imgLink = fixImgurLink(imgLink)
 			ret = append(ret, imgLink)
 			foundImage = true
 		}


### PR DESCRIPTION
This pull request introduces enhancements to the handling of HTTP requests and imgur links in the `base.go` and `ptt.go` files. The most important changes include adding a User-Agent header to HTTP requests and creating a helper function to standardize imgur links.

Enhancements to HTTP requests:

* [`base.go`](diffhunk://#diff-70f1ecb7be66d191151d77019a75ef0ba0404acdcbaf1aa630099ed46d208771L82-R97): Added a User-Agent header to HTTP requests in the `worker` function.

Standardizing imgur links:

* [`ptt.go`](diffhunk://#diff-522f282fa39393ca5603e535169b84c46e5e21c4fdcde94ef46d5264e128118bR46-R62): Added a helper function `fixImgurLink` to standardize imgur links by converting them to direct image links. This helper function is now used in multiple functions (`extractImageLinks`, `GetAllFromURL`, and `GetAllImageAddress`) to ensure consistency. [[1]](diffhunk://#diff-522f282fa39393ca5603e535169b84c46e5e21c4fdcde94ef46d5264e128118bR46-R62) [[2]](diffhunk://#diff-522f282fa39393ca5603e535169b84c46e5e21c4fdcde94ef46d5264e128118bL82-R92) [[3]](diffhunk://#diff-522f282fa39393ca5603e535169b84c46e5e21c4fdcde94ef46d5264e128118bL180-R189)…handling for improved accuracy